### PR TITLE
Add script to automatically connect wlan on startup

### DIFF
--- a/scripts/connect_wlan.sh
+++ b/scripts/connect_wlan.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -euxo pipefail
+
+wlan_iface=$1
+
+ctrl_iface=/var/run/wpa_supplicant/${wlan_iface}
+sudo rm -f $ctrl_iface
+
+sudo wpa_supplicant -B -i $wlan_iface -c /etc/wpa_supplicant/tesla_gateway.conf -D nl80211,wext
+
+sleep 5s
+sudo iw $wlan_iface link


### PR DESCRIPTION
Note that the setup script will be responsible for adding a new cron job (`sudo crontab -e`) to call this script on startup. It is also important to note that the commands in this script require elevate privileges. 

Example:
```
@reboot bash /home/pi/src/raspi-tesla/scripts/connect_wlan.sh <interface>
```